### PR TITLE
chore: update shiki version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"peerDependencies": {
-		"shiki": "^0.11.1"
+		"shiki": "^0.11.1 || ^0.12.0"
 	},
 	"devDependencies": {
 		"@antfu/ni": "^0.18.2",


### PR DESCRIPTION
It's working fine with shiki@0.12.1, but pnpm is giving missing peer deps warning currently. (`^0.11.1` won't match `0.12.1`)